### PR TITLE
docs: clarify that bare 'countrystatecity' is not a published package

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Official Python packages for accessing comprehensive countries, states, and citi
 
 ## 📦 Available Packages
 
-> **Note:** All Python distributions are published with an entity suffix (e.g. `countrystatecity-countries`). There is no bare `countrystatecity` package on PyPI — `pip install countrystatecity` will fail with *"Could not find a version that satisfies the requirement"*. Pick the suffixed package you need from the list below.
+> **Note:** All Python distributions are published with an entity suffix (e.g. `countrystatecity-countries`). Currently there is no bare `countrystatecity` package on PyPI, so `pip install countrystatecity` may not work as expected. Pick the suffixed package you need from the list below.
 
 ### Priority 1 (Released)
 - **[countrystatecity-countries](./python/packages/countries/)** - Countries, states, and cities database with type hints and lazy loading

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Official Python packages for accessing comprehensive countries, states, and citi
 
 ## 📦 Available Packages
 
+> **Note:** All Python distributions are published with an entity suffix (e.g. `countrystatecity-countries`). There is no bare `countrystatecity` package on PyPI — `pip install countrystatecity` will fail with *"Could not find a version that satisfies the requirement"*. Pick the suffixed package you need from the list below.
+
 ### Priority 1 (Released)
 - **[countrystatecity-countries](./python/packages/countries/)** - Countries, states, and cities database with type hints and lazy loading
 
@@ -24,6 +26,8 @@ Official Python packages for accessing comprehensive countries, states, and citi
 ```bash
 pip install countrystatecity-countries
 ```
+
+> ⚠️ Don't run `pip install countrystatecity` — that name is unpublished. Always include the entity suffix (`-countries`, `-timezones`, etc.).
 
 ### Usage
 


### PR DESCRIPTION
## Summary

- Adds a short note under **Available Packages** explaining that all distributions are published with an entity suffix.
- Adds a warning callout right under the **Installation** snippet so anyone scanning the README sees, before they retype, that `pip install countrystatecity` will fail.

## Context

User reported in dr5hn/countries-states-cities-database#1375 that `pip install countrystatecity` returns *"Could not find a version that satisfies the requirement countrystatecity (from versions: none)"*. The bare name is not reserved on PyPI; only the suffixed packages (currently `countrystatecity-countries` 1.0.2) exist.

Neither this repo's README nor the upstream `countries-states-cities-database` README contained the wrong command — both already use `countrystatecity-countries`. So this change is **preventive documentation**: a small amount of noise to short-circuit the next user who guesses the bare name.

## Test plan
- [ ] Render the README on GitHub and confirm both callouts appear and read cleanly
- [ ] Confirm no other changes are bundled (only `README.md` is touched)

## Out of scope
- Reserving `countrystatecity` on PyPI as a metapackage — worth considering as a follow-up; not done here.
- Mirroring the same note into the upstream `countries-states-cities-database` README — happy to open a separate PR there if you'd like.

Refs dr5hn/countries-states-cities-database#1375

🤖 Generated with [Claude Code](https://claude.com/claude-code)